### PR TITLE
Fix initialization order

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -8,12 +8,12 @@ Copyright 2018, Ihor Melnyk
 OpenTherm::OpenTherm(int inPin, int outPin):
 	inPin(inPin),
 	outPin(outPin),	
-	handleInterruptCallback(NULL),
-	processResponseCallback(NULL),
 	status(OpenThermStatus::NOT_INITIALIZED),	
 	response(0),
 	responseStatus(OpenThermResponseStatus::NONE),
-	responseTimestamp(0)	
+	responseTimestamp(0),
+	handleInterruptCallback(NULL),
+	processResponseCallback(NULL)
 {
 }
 


### PR DESCRIPTION
Fixes the following compiler warning:

In file included from /home/dw/Arduino/libraries/opentherm_library/src/OpenTherm.cpp:6:0:
/home/dw/Arduino/libraries/opentherm_library/src/OpenTherm.h: In constructor 'OpenTherm::OpenTherm(int, int)':
/home/dw/Arduino/libraries/opentherm_library/src/OpenTherm.h:120:71: warning: 'OpenTherm::processResponseCallback' will be initialized after [-Wreorder]
  void(*processResponseCallback)(unsigned long, OpenThermResponseStatus);
                                                                       ^
/home/dw/Arduino/libraries/opentherm_library/src/OpenTherm.h:105:27: warning:   'volatile OpenThermStatus OpenTherm::status' [-Wreorder]
  volatile OpenThermStatus status;
                           ^
/home/dw/Arduino/libraries/opentherm_library/src/OpenTherm.cpp:8:1: warning:   when initialized here [-Wreorder]
 OpenTherm::OpenTherm(int inPin, int outPin):
 ^