### PR TITLE
Fix handling of values of temperature below zero.

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -260,8 +260,19 @@ bool OpenTherm::isDiagnostic(unsigned long response) {
 	return response & 0x40;
 }
 
+uint16_t OpenTherm::getUInt(const unsigned long response) const {
+	const uint16_t u88 = response & 0xffff;
+	return u88;
+}
+
+float OpenTherm::getFloat(const unsigned long response) const {
+	const uint16_t u88 = getUInt(response);
+	const float f = (u88 & 0x8000) ? -(0x10000L - u88) / 256.0f : u88 / 256.0f;
+	return f;
+}
+
 float OpenTherm::getTemperature(unsigned long response) {
-	float temperature = isValidResponse(response) ? (response & 0xFFFF) / 256.0 : 0;
+	float temperature = isValidResponse(response) ? getFloat(response) : 0;
 	return temperature;
 }
 

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -13,6 +13,7 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #ifndef OpenTherm_h
 #define OpenTherm_h
 
+#include <stdint.h>
 #include <Arduino.h>
 
 enum OpenThermResponseStatus {
@@ -142,7 +143,9 @@ public:
 	bool isHotWaterEnabled(unsigned long response);
 	bool isFlameOn(unsigned long response);
 	bool isCoolingEnabled(unsigned long response);
-	bool isDiagnostic(unsigned long response);	
+	bool isDiagnostic(unsigned long response);
+	uint16_t getUInt(const unsigned long response) const;
+	float getFloat(const unsigned long response) const;
 	float getTemperature(unsigned long response);
 	unsigned int temperatureToData(float temperature);
 


### PR DESCRIPTION
- Add dedicated getFloat() to retrieve f8.8 type value.
- Add getUInt() to retrieve u8 / u8 type value.