### PR TITLE
Introduce OT namespce to avoid clash with other libraries

### DIFF
--- a/examples/OpenTherm_Demo/OpenTherm_Demo.ino
+++ b/examples/OpenTherm_Demo/OpenTherm_Demo.ino
@@ -23,6 +23,8 @@ but since GPIO6-GPIO11 are typically used to interface with the flash memory ICs
 #include <Arduino.h>
 #include <OpenTherm.h>
 
+using namespace OT;
+
 const int inPin = 2; //4
 const int outPin = 3; //5
 OpenTherm ot(inPin, outPin);

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -4,6 +4,7 @@ Copyright 2018, Ihor Melnyk
 */
 
 #include "OpenTherm.h"
+namespace OT {
 
 OpenTherm::OpenTherm(int inPin, int outPin):
 	inPin(inPin),
@@ -298,3 +299,5 @@ float OpenTherm::getBoilerTemperature() {
 	unsigned long response = sendRequest(buildGetBoilerTemperatureRequest());
 	return getTemperature(response);
 }
+
+} // namespace OT

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -16,6 +16,8 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <stdint.h>
 #include <Arduino.h>
 
+namespace OT {
+
 enum OpenThermResponseStatus {
 	NONE,
 	SUCCESS,
@@ -154,5 +156,7 @@ public:
 	bool setBoilerTemperature(float temperature);
 	float getBoilerTemperature();
 };
+
+} // namespace OT
 
 #endif // OpenTherm_h


### PR DESCRIPTION
Fixes the following clash with STM32 platform from:
  https://github.com/stm32duino/Arduino_Core_STM32

opentherm_library/src/OpenTherm.h:21:2: error: 'SUCCESS' conflicts with a previous declaration
  SUCCESS,
  ^~~~~~~
In file included from /home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/cores/arduino/stm32/stm32_def.h:29,
                 from /home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/cores/arduino/stm32/clock.h:43,
                 from /home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/cores/arduino/wiring_time.h:23,
                 from /home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/cores/arduino/wiring.h:38,
                 from /home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/cores/arduino/Arduino.h:32,
                 from /home/sw/Arduino/OT-Adapter/.build/sketch/OT-Adapter.ino.cpp:1:
/home/sw/.arduino15/packages/STM32/hardware/stm32/1.6.0-dev/system/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f1xx.h:185:3: note: previous declaration 'ErrorStatus SUCCESS'
   SUCCESS = !ERROR
   ^~~~~~~