### PR TITLE
Fixed clashing with SPIFFS write operations

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -36,12 +36,12 @@ void OpenTherm::begin(void(*handleInterruptCallback)(void))
 	begin(handleInterruptCallback, NULL);	
 }
 
-bool OpenTherm::isReady()
+bool ICACHE_RAM_ATTR OpenTherm::isReady()
 {
 	return status == OpenThermStatus::READY;
 }
 
-int OpenTherm::readState() {
+int ICACHE_RAM_ATTR OpenTherm::readState() {
 	return digitalRead(inPin);
 }
 
@@ -122,7 +122,7 @@ OpenThermResponseStatus OpenTherm::getLastResponseStatus()
 	return responseStatus;
 }
 
-void OpenTherm::handleInterrupt()
+void ICACHE_RAM_ATTR OpenTherm::handleInterrupt()
 {	
     if (isReady())
     {


### PR DESCRIPTION
Here is a problem - when you do any flash modification operations (for example when your writing any file with SPIFFS filesystem )  - flash is detached from core address space and if OT library receives an interrupt it will fail with exception because there is no further instructions to execute (flash is detached).  Caching code in RAM for handler and called functions with ICACHE_RAM_ATTR resolves an issue.