### PR TITLE
1. Fixup reorder error; 2. Cosmetics

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -376,3 +376,22 @@ float OpenTherm::getBoilerTemperature() {
 	unsigned long response = sendRequest(buildGetBoilerTemperatureRequest());
 	return getTemperature(response);
 }
+
+float OpenTherm::getRetTemperature() {
+    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::Tret, 0));
+    return getTemperature(response);
+}
+
+float OpenTherm::getModulation() {
+    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::RelModLevel, 0));
+    return getTemperature(response);
+}
+
+float OpenTherm::getPressure() {
+    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::CHPressure, 0));
+    return getTemperature(response);
+}
+
+unsigned char OpenTherm::getFault() {
+    return ((sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0)) >> 8) & 0xff);
+}

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -141,7 +141,7 @@ public:
 	unsigned long buildSetBoilerTemperatureRequest(float temperature);
 	unsigned long buildGetBoilerTemperatureRequest();   g
 
-	//responses   g
+	//responses
 	bool isFault(unsigned long response);
 	bool isCentralHeatingActive(unsigned long response);
 	bool isHotWaterActive(unsigned long response);
@@ -157,6 +157,10 @@ public:
 	unsigned long setBoilerStatus(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
 	bool setBoilerTemperature(float temperature);
 	float getBoilerTemperature();
+    float getRetTemperature();
+    float getModulation();
+    float getPressure();
+    unsigned char getFault();
 
 private:
 	const int inPin;

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -51,20 +51,20 @@ enum OpenThermMessageID {
 	RBPflags, // flag8 / flag8  Remote boiler parameter transfer-enable & read/write flags
 	CoolingControl, // f8.8  Cooling control signal (%)
 	TsetCH2, // f8.8  Control setpoint for 2e CH circuit (°C)
-	TrOverride, // f8.8  Remote override room setpointg
-	TSP, // u8 / u8  Number of Transparent-Slave-Parameters supported by slaveg
-	TSPindexTSPvalue, // u8 / u8  Index number / Value of referred-to transparent slave parameter.g
-	FHBsize, // u8 / u8  Size of Fault-History-Buffer supported by slaveg
-	FHBindexFHBvalue, // u8 / u8  Index number / Value of referred-to fault-history buffer entry.g
-	MaxRelModLevelSetting, // f8.8  Maximum relative modulation level setting (%)g
-	MaxCapacityMinModLevel, // u8 / u8  Maximum boiler capacity (kW) / Minimum boiler modulation level(%)g
+	TrOverride, // f8.8  Remote override room setpoint
+	TSP, // u8 / u8  Number of Transparent-Slave-Parameters supported by slave
+	TSPindexTSPvalue, // u8 / u8  Index number / Value of referred-to transparent slave parameter.
+	FHBsize, // u8 / u8  Size of Fault-History-Buffer supported by slave
+	FHBindexFHBvalue, // u8 / u8  Index number / Value of referred-to fault-history buffer entry.
+	MaxRelModLevelSetting, // f8.8  Maximum relative modulation level setting (%)
+	MaxCapacityMinModLevel, // u8 / u8  Maximum boiler capacity (kW) / Minimum boiler modulation level(%)
 	TrSet, // f8.8  Room Setpoint (°C)
-	RelModLevel, // f8.8  Relative Modulation Level (%)g
-	CHPressure, // f8.8  Water pressure in CH circuit  (bar)g
-	DHWFlowRate, // f8.8  Water flow rate in DHW circuit. (litres/minute)g
-	DayTime, // special / u8  Day of Week and Time of Dayg
-	Date, // u8 / u8  Calendar dateg
-	Year, // u16  Calendar yearg
+	RelModLevel, // f8.8  Relative Modulation Level (%)
+	CHPressure, // f8.8  Water pressure in CH circuit  (bar)
+	DHWFlowRate, // f8.8  Water flow rate in DHW circuit. (litres/minute)
+	DayTime, // special / u8  Day of Week and Time of Day
+	Date, // u8 / u8  Calendar date
+	Year, // u16  Calendar year
 	TrSetCH2, // f8.8  Room Setpoint for 2nd CH circuit (°C)
 	Tr, // f8.8  Room temperature (°C)
 	Tboiler, // f8.8  Boiler flow water temperature (°C)
@@ -78,23 +78,23 @@ enum OpenThermMessageID {
 	Texhaust, // s16  Boiler exhaust temperature (°C)
 	TdhwSetUBTdhwSetLB = 48, // s8 / s8  DHW setpoint upper & lower bounds for adjustment  (°C)
 	MaxTSetUBMaxTSetLB, // s8 / s8  Max CH water setpoint upper & lower bounds for adjustment  (°C)
-	HcratioUBHcratioLB, // s8 / s8  OTC heat curve ratio upper & lower bounds for adjustment g
+	HcratioUBHcratioLB, // s8 / s8  OTC heat curve ratio upper & lower bounds for adjustment
 	TdhwSet = 56, // f8.8  DHW setpoint (°C)    (Remote parameter 1)
 	MaxTSet, // f8.8  Max CH water setpoint (°C)  (Remote parameters 2)
 	Hcratio, // f8.8  OTC heat curve ratio (°C)  (Remote parameter 3)
-	RemoteOverrideFunction = 100, // flag8 / -  Function of manual and program changes in master and remote room setpoint.g
-	OEMDiagnosticCode = 115, // u16  OEM-specific diagnostic/service codeg
-	BurnerStarts, // u16  Number of starts burnerg
-	CHPumpStarts, // u16  Number of starts CH pumpg
-	DHWPumpValveStarts, // u16  Number of starts DHW pump/valveg
-	DHWBurnerStarts, // u16  Number of starts burner during DHW modeg
-	BurnerOperationHours, // u16  Number of hours that burner is in operation (i.e. flame on)g
-	CHPumpOperationHours, // u16  Number of hours that CH pump has been runningg
-	DHWPumpValveOperationHours, // u16  Number of hours that DHW pump has been running or DHW valve has been openedg
-	DHWBurnerOperationHours, // u16  Number of hours that burner is in operation during DHW modeg
-	OpenThermVersionMaster, // f8.8  The implemented version of the OpenTherm Protocol Specification in the master.g
-	OpenThermVersionSlave, // f8.8  The implemented version of the OpenTherm Protocol Specification in the slave.g
-	MasterVersion, // u8 / u8  Master product version number and typeg
+	RemoteOverrideFunction = 100, // flag8 / -  Function of manual and program changes in master and remote room setpoint.
+	OEMDiagnosticCode = 115, // u16  OEM-specific diagnostic/service code
+	BurnerStarts, // u16  Number of starts burner
+	CHPumpStarts, // u16  Number of starts CH pump
+	DHWPumpValveStarts, // u16  Number of starts DHW pump/valve
+	DHWBurnerStarts, // u16  Number of starts burner during DHW mode
+	BurnerOperationHours, // u16  Number of hours that burner is in operation (i.e. flame on)
+	CHPumpOperationHours, // u16  Number of hours that CH pump has been running
+	DHWPumpValveOperationHours, // u16  Number of hours that DHW pump has been running or DHW valve has been opened
+	DHWBurnerOperationHours, // u16  Number of hours that burner is in operation during DHW mode
+	OpenThermVersionMaster, // f8.8  The implemented version of the OpenTherm Protocol Specification in the master.
+	OpenThermVersionSlave, // f8.8  The implemented version of the OpenTherm Protocol Specification in the slave.
+	MasterVersion, // u8 / u8  Master product version number and type
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
@@ -139,7 +139,7 @@ public:
 	//requests
 	unsigned long buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
 	unsigned long buildSetBoilerTemperatureRequest(float temperature);
-	unsigned long buildGetBoilerTemperatureRequest();   g
+	unsigned long buildGetBoilerTemperatureRequest();
 
 	//responses
 	bool isFault(unsigned long response);

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -42,29 +42,29 @@ enum OpenThermMessageType {
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
 
 enum OpenThermMessageID {
-	Status, // flag8 / flag8  Master and Slave Status flags. 
+	Status, // flag8 / flag8  Master and Slave Status flags.
 	TSet, // f8.8  Control setpoint  ie CH  water temperature setpoint (°C)
-	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code 
-	SConfigSMemberIDcode, // flag8 / u8  Slave Configuration Flags /  Slave MemberID Code 
-	Command, // u8 / u8  Remote Command 
-	ASFflags, // / OEM-fault-code  flag8 / u8  Application-specific fault flags and OEM fault code 
-	RBPflags, // flag8 / flag8  Remote boiler parameter transfer-enable & read/write flags 
-	CoolingControl, // f8.8  Cooling control signal (%) 
+	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code
+	SConfigSMemberIDcode, // flag8 / u8  Slave Configuration Flags /  Slave MemberID Code
+	Command, // u8 / u8  Remote Command
+	ASFflags, // / OEM-fault-code  flag8 / u8  Application-specific fault flags and OEM fault code
+	RBPflags, // flag8 / flag8  Remote boiler parameter transfer-enable & read/write flags
+	CoolingControl, // f8.8  Cooling control signal (%)
 	TsetCH2, // f8.8  Control setpoint for 2e CH circuit (°C)
-	TrOverride, // f8.8  Remote override room setpoint 
-	TSP, // u8 / u8  Number of Transparent-Slave-Parameters supported by slave 
-	TSPindexTSPvalue, // u8 / u8  Index number / Value of referred-to transparent slave parameter. 
-	FHBsize, // u8 / u8  Size of Fault-History-Buffer supported by slave 
-	FHBindexFHBvalue, // u8 / u8  Index number / Value of referred-to fault-history buffer entry. 
-	MaxRelModLevelSetting, // f8.8  Maximum relative modulation level setting (%) 
-	MaxCapacityMinModLevel, // u8 / u8  Maximum boiler capacity (kW) / Minimum boiler modulation level(%) 
+	TrOverride, // f8.8  Remote override room setpointg
+	TSP, // u8 / u8  Number of Transparent-Slave-Parameters supported by slaveg
+	TSPindexTSPvalue, // u8 / u8  Index number / Value of referred-to transparent slave parameter.g
+	FHBsize, // u8 / u8  Size of Fault-History-Buffer supported by slaveg
+	FHBindexFHBvalue, // u8 / u8  Index number / Value of referred-to fault-history buffer entry.g
+	MaxRelModLevelSetting, // f8.8  Maximum relative modulation level setting (%)g
+	MaxCapacityMinModLevel, // u8 / u8  Maximum boiler capacity (kW) / Minimum boiler modulation level(%)g
 	TrSet, // f8.8  Room Setpoint (°C)
-	RelModLevel, // f8.8  Relative Modulation Level (%) 
-	CHPressure, // f8.8  Water pressure in CH circuit  (bar) 
-	DHWFlowRate, // f8.8  Water flow rate in DHW circuit. (litres/minute) 
-	DayTime, // special / u8  Day of Week and Time of Day 
-	Date, // u8 / u8  Calendar date 
-	Year, // u16  Calendar year 
+	RelModLevel, // f8.8  Relative Modulation Level (%)g
+	CHPressure, // f8.8  Water pressure in CH circuit  (bar)g
+	DHWFlowRate, // f8.8  Water flow rate in DHW circuit. (litres/minute)g
+	DayTime, // special / u8  Day of Week and Time of Dayg
+	Date, // u8 / u8  Calendar dateg
+	Year, // u16  Calendar yearg
 	TrSetCH2, // f8.8  Room Setpoint for 2nd CH circuit (°C)
 	Tr, // f8.8  Room temperature (°C)
 	Tboiler, // f8.8  Boiler flow water temperature (°C)
@@ -78,23 +78,23 @@ enum OpenThermMessageID {
 	Texhaust, // s16  Boiler exhaust temperature (°C)
 	TdhwSetUBTdhwSetLB = 48, // s8 / s8  DHW setpoint upper & lower bounds for adjustment  (°C)
 	MaxTSetUBMaxTSetLB, // s8 / s8  Max CH water setpoint upper & lower bounds for adjustment  (°C)
-	HcratioUBHcratioLB, // s8 / s8  OTC heat curve ratio upper & lower bounds for adjustment  
+	HcratioUBHcratioLB, // s8 / s8  OTC heat curve ratio upper & lower bounds for adjustment g
 	TdhwSet = 56, // f8.8  DHW setpoint (°C)    (Remote parameter 1)
 	MaxTSet, // f8.8  Max CH water setpoint (°C)  (Remote parameters 2)
 	Hcratio, // f8.8  OTC heat curve ratio (°C)  (Remote parameter 3)
-	RemoteOverrideFunction = 100, // flag8 / -  Function of manual and program changes in master and remote room setpoint. 
-	OEMDiagnosticCode = 115, // u16  OEM-specific diagnostic/service code 
-	BurnerStarts, // u16  Number of starts burner 
-	CHPumpStarts, // u16  Number of starts CH pump 
-	DHWPumpValveStarts, // u16  Number of starts DHW pump/valve 
-	DHWBurnerStarts, // u16  Number of starts burner during DHW mode 
-	BurnerOperationHours, // u16  Number of hours that burner is in operation (i.e. flame on) 
-	CHPumpOperationHours, // u16  Number of hours that CH pump has been running 
-	DHWPumpValveOperationHours, // u16  Number of hours that DHW pump has been running or DHW valve has been opened 
-	DHWBurnerOperationHours, // u16  Number of hours that burner is in operation during DHW mode 
-	OpenThermVersionMaster, // f8.8  The implemented version of the OpenTherm Protocol Specification in the master. 
-	OpenThermVersionSlave, // f8.8  The implemented version of the OpenTherm Protocol Specification in the slave. 
-	MasterVersion, // u8 / u8  Master product version number and type 
+	RemoteOverrideFunction = 100, // flag8 / -  Function of manual and program changes in master and remote room setpoint.g
+	OEMDiagnosticCode = 115, // u16  OEM-specific diagnostic/service codeg
+	BurnerStarts, // u16  Number of starts burnerg
+	CHPumpStarts, // u16  Number of starts CH pumpg
+	DHWPumpValveStarts, // u16  Number of starts DHW pump/valveg
+	DHWBurnerStarts, // u16  Number of starts burner during DHW modeg
+	BurnerOperationHours, // u16  Number of hours that burner is in operation (i.e. flame on)g
+	CHPumpOperationHours, // u16  Number of hours that CH pump has been runningg
+	DHWPumpValveOperationHours, // u16  Number of hours that DHW pump has been running or DHW valve has been openedg
+	DHWBurnerOperationHours, // u16  Number of hours that burner is in operation during DHW modeg
+	OpenThermVersionMaster, // f8.8  The implemented version of the OpenTherm Protocol Specification in the master.g
+	OpenThermVersionSlave, // f8.8  The implemented version of the OpenTherm Protocol Specification in the slave.g
+	MasterVersion, // u8 / u8  Master product version number and typeg
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
@@ -107,59 +107,41 @@ enum OpenThermStatus {
 	RESPONSE_START_BIT,
 	RESPONSE_RECEIVING,
 	RESPONSE_READY,
-	RESPONSE_INVALID	
+	RESPONSE_INVALID
 };
 
 class OpenTherm
 {
-private:
-	const int inPin;
-	const int outPin;
-    const bool isSlave;
-	
-	volatile unsigned long response;
-	volatile OpenThermResponseStatus responseStatus;
-	volatile unsigned long responseTimestamp;
-	volatile byte responseBitIndex;
-	
-	int readState();
-	void setActiveState();
-	void setIdleState();	
-	void activateBoiler();
-
-    void sendBit(bool high);    
-    void(*handleInterruptCallback)();
-    void(*processResponseCallback)(unsigned long, OpenThermResponseStatus);
-public:	
-    volatile OpenThermStatus status;
+public:
 	OpenTherm(int inPin = 4, int outPin = 5, bool isSlave = false);
+	volatile OpenThermStatus status;
 	void begin(void(*handleInterruptCallback)(void));
 	void begin(void(*handleInterruptCallback)(void), void(*processResponseCallback)(unsigned long, OpenThermResponseStatus));
 	bool isReady();
 	unsigned long sendRequest(unsigned long request);
-    bool sendResponse(unsigned long request);
+	bool sendResponse(unsigned long request);
 	bool sendRequestAync(unsigned long request);
 	unsigned long buildRequest(OpenThermMessageType type, OpenThermMessageID id, unsigned int data);
-    unsigned long buildResponse(OpenThermMessageType type, OpenThermMessageID id, unsigned int data);
+	unsigned long buildResponse(OpenThermMessageType type, OpenThermMessageID id, unsigned int data);
 	OpenThermResponseStatus getLastResponseStatus();
 	const char *statusToString(OpenThermResponseStatus status);
-	void handleInterrupt();	
+	void handleInterrupt();
 	void process();
 	void end();
 
-    bool parity(unsigned long frame);
+	bool parity(unsigned long frame);
 	OpenThermMessageType getMessageType(unsigned long message);
-    OpenThermMessageID getDataID(unsigned long frame);
+	OpenThermMessageID getDataID(unsigned long frame);
 	const char *messageTypeToString(OpenThermMessageType message_type);
-    bool isValidRequest(unsigned long request);
-    bool isValidResponse(unsigned long response);
+	bool isValidRequest(unsigned long request);
+	bool isValidResponse(unsigned long response);
 
 	//requests
 	unsigned long buildSetBoilerStatusRequest(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
 	unsigned long buildSetBoilerTemperatureRequest(float temperature);
-	unsigned long buildGetBoilerTemperatureRequest();    
+	unsigned long buildGetBoilerTemperatureRequest();   g
 
-	//responses    
+	//responses   g
 	bool isFault(unsigned long response);
 	bool isCentralHeatingActive(unsigned long response);
 	bool isHotWaterActive(unsigned long response);
@@ -172,13 +154,28 @@ public:
 	unsigned int temperatureToData(float temperature);
 
 	//basic requests
-	unsigned long setBoilerStatus(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);	
+	unsigned long setBoilerStatus(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
 	bool setBoilerTemperature(float temperature);
 	float getBoilerTemperature();
-};
 
-#ifndef ICACHE_RAM_ATTR
-#define ICACHE_RAM_ATTR
-#endif
+private:
+	const int inPin;
+	const int outPin;
+	const bool isSlave;
+
+	volatile unsigned long response;
+	volatile OpenThermResponseStatus responseStatus;
+	volatile unsigned long responseTimestamp;
+	volatile byte responseBitIndex;
+
+	int readState();
+	void setActiveState();
+	void setIdleState();
+	void activateBoiler();
+
+	void sendBit(bool high);
+	void(*handleInterruptCallback)();
+	void(*processResponseCallback)(unsigned long, OpenThermResponseStatus);
+};
 
 #endif // OpenTherm_h


### PR DESCRIPTION
This PR closes this Issue: https://github.com/ihormelnyk/opentherm_library/issues/20
Second change is cosmetic clean-up: I've substituted all four-spaces to tabs and removed trailing spaces.
Helper functions added to get return temperature, modulation level, coolant pressure and fault code.