### PR TITLE
Basic HVAC/Ventilation system support

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -390,3 +390,76 @@ float OpenTherm::getPressure() {
 unsigned char OpenTherm::getFault() {
     return ((sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0)) >> 8) & 0xff);
 }
+
+unsigned int OpenTherm::getVentilation() {
+	unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::VentNomVent, 0));
+	return isValidResponse(response) ? getUInt(response) : 0;
+}
+
+/** Setting the nominal ventilation, clamps to the range 0-100
+ * Some ventilation systems have special values for nominal value 0,1,2,3
+ */
+unsigned int OpenTherm::setVentilation(unsigned int nominal_value) {
+	if (nominal_value < 0) nominal_value = 0;
+	if (nominal_value > 100) nominal_value = 100;
+	unsigned long response = sendRequest(buildRequest(OpenThermRequestType::WRITE, OpenThermMessageID::VentNomVentSet, nominal_value));
+	return isValidResponse(response) ? getUInt(response) : 0;
+}
+
+/**
+ * Temperature getting functions for Vent systems
+ * Often respond with temperature '80' when the sensors aren't available
+ */
+float OpenTherm::getVentSupplyInTemperature() {
+	unsigned long response = sendRequest(
+		buildRequest(OpenThermRequestType::READ, OpenThermMessageID::VentTsupplyin, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
+}
+
+float OpenTherm::getVentSupplyOutTemperature() {
+	unsigned long response = sendRequest(
+		buildRequest(OpenThermRequestType::READ, OpenThermMessageID::VentTsupplyout, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
+}
+
+float OpenTherm::getVentExhaustInTemperature() {
+	unsigned long response = sendRequest(
+		buildRequest(OpenThermRequestType::READ, OpenThermMessageID::VentTexhaustin, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
+}
+
+float OpenTherm::getVentExhaustOutTemperature() {
+	unsigned long response = sendRequest(
+		buildRequest(OpenThermRequestType::READ, OpenThermMessageID::VentTexhaustout, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
+}
+
+bool OpenTherm::getFaultIndication() {
+	unsigned long response = sendRequest(buildRequest(
+		OpenThermRequestType::READ, OpenThermMessageID::VentStatus,0));
+	return isValidResponse(response)? (getUInt(response) & 0x1) : 0;
+}
+
+bool OpenTherm::getVentilationMode() {
+	unsigned long response = sendRequest(buildRequest(
+		OpenThermRequestType::READ, OpenThermMessageID::VentStatus,0));
+	return isValidResponse(response) ? (getUInt(response) & 0x2) >> 1: 0;
+}
+
+bool OpenTherm::getBypassStatus() {
+	unsigned long response = sendRequest(buildRequest(
+		OpenThermRequestType::READ, OpenThermMessageID::VentStatus,0));
+	return isValidResponse(response) ? (getUInt(response) & 0x4) >> 2: 0;
+}
+
+bool OpenTherm::getBypassAutomaticStatus() {
+	unsigned long response = sendRequest(buildRequest(
+		OpenThermRequestType::READ, OpenThermMessageID::VentStatus,0));
+	return isValidResponse(response) ? (getUInt(response) & 0x8) >> 3: 0;
+}
+
+bool OpenTherm::getDiagnosticIndication() {
+	unsigned long response = sendRequest(buildRequest(
+		OpenThermRequestType::READ, OpenThermMessageID::VentStatus,0));
+	return isValidResponse(response)? (getUInt(response) & 0x20) >> 5: 0;
+}

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -82,6 +82,24 @@ enum OpenThermMessageID {
 	TdhwSet = 56, // f8.8  DHW setpoint (°C)    (Remote parameter 1)
 	MaxTSet, // f8.8  Max CH water setpoint (°C)  (Remote parameters 2)
 	Hcratio, // f8.8  OTC heat curve ratio (°C)  (Remote parameter 3)
+
+	// Ventilation Specific Message IDs
+	VentStatus = 70, // flag8 / flag8  Master and Slave Status flags specific to Vent systems
+	VentNomVentSet, // _ / u8 Set the relative ventilation 0-100%
+	VentFault, // flag8 / flag8 Application specific fault flags
+	VentOEMFault, // flag8 / flag8 Oem specific fault flags
+	VentSlaveVentConfig = 74, // Slave Configuration Flags /  Slave MemberID Code
+	VentNomVent = 77, // _ / u8 Read the relative ventilation 0-100%
+	VentRelHumid, // _ / u8 Read the relative humidity 0-100%
+	VentCO2level, // u16 CO2 level in PPM (0-2000)
+	VentTsupplyin, // f8.8 Supply Outlet temperature
+	VentTsupplyout, // f8.8 Supply Outlet temperature
+	VentTexhaustin,// f8.8 Exhaust Inlet temperature
+	VentTexhaustout, // f8.8 Exhaust Outlet temperature
+	VentRPMexhaust, // u16 Actual RPM for inlet fan
+	VentRPMsupply, // u16 Actual RPM for supply fan
+	VentNomRelVent = 87, // _ / u8 Get the current relative ventilation
+
 	RemoteOverrideFunction = 100, // flag8 / -  Function of manual and program changes in master and remote room setpoint.
 	OEMDiagnosticCode = 115, // u16  OEM-specific diagnostic/service code
 	BurnerStarts, // u16  Number of starts burner
@@ -161,6 +179,21 @@ public:
     float getModulation();
     float getPressure();
     unsigned char getFault();
+
+	//Ventilation systems requests
+	unsigned int getVentilation();
+	unsigned int setVentilation(unsigned int nominal_value);
+	float getVentSupplyInTemperature();
+	float getVentSupplyOutTemperature();
+	float getVentExhaustInTemperature();
+	float getVentExhaustOutTemperature();
+
+	bool getFaultIndication();
+	bool getVentilationMode();
+	bool getBypassStatus();
+	bool getBypassAutomaticStatus();
+	bool getDiagnosticIndication();
+
 
 private:
 	const int inPin;


### PR DESCRIPTION
This merge request adds basic support for ventilation systems.
Adds reading of the temperature sensors, some diagnostic info and fan control.

OpenThermIDs based on various spec sheets: 'OpenTherm Technical Specifications v2.3b' and 'OpenTherm-Function-Matrix-v1_0.xls'

Tested (and currently in use) for a Brink HRV.