### PR TITLE
OT stop bit verification

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -162,7 +162,8 @@ void ICACHE_RAM_ATTR OpenTherm::handleInterrupt()
 		}
 	}
 	else if (status == OpenThermStatus::RESPONSE_RECEIVING) {
-		if ((newTs - responseTimestamp) > 750) {
+		uint32 bitDuration = newTs - responseTimestamp;
+		if ((newTs - responseTimestamp) > 750 && bitDuration < 1300) { // bitDuration should not bigger than 1500
 			if (responseBitIndex < 32) {
 				response = (response << 1) | !readState();
 				responseTimestamp = newTs;


### PR DESCRIPTION
With new OT version and OT certificate tool, there’s mandatorily stop bit verification. This small change fixed the issue.