### PR TITLE
Use IRAM_ATTR in place of ICACHE_RAM_ATTR (with backward compatibility)

### DIFF
--- a/examples/OpenThermGatewayMonitor_Demo/OpenThermGatewayMonitor_Demo.ino
+++ b/examples/OpenThermGatewayMonitor_Demo/OpenThermGatewayMonitor_Demo.ino
@@ -18,11 +18,11 @@ const int sOutPin = 5; //for Arduino, 13 for ESP8266 (D7), 23 for ESP32
 OpenTherm mOT(mInPin, mOutPin);
 OpenTherm sOT(sInPin, sOutPin, true);
 
-void ICACHE_RAM_ATTR mHandleInterrupt() {
+void IRAM_ATTR mHandleInterrupt() {
     mOT.handleInterrupt();
 }
 
-void ICACHE_RAM_ATTR sHandleInterrupt() {
+void IRAM_ATTR sHandleInterrupt() {
     sOT.handleInterrupt();
 }
 

--- a/examples/OpenThermMaster_Demo/OpenThermMaster_Demo.ino
+++ b/examples/OpenThermMaster_Demo/OpenThermMaster_Demo.ino
@@ -27,7 +27,7 @@ const int inPin = 2;  //for Arduino, 4 for ESP8266 (D2), 21 for ESP32
 const int outPin = 3; //for Arduino, 5 for ESP8266 (D1), 22 for ESP32
 OpenTherm ot(inPin, outPin);
 
-void ICACHE_RAM_ATTR handleInterrupt() {
+void IRAM_ATTR handleInterrupt() {
     ot.handleInterrupt();
 }
 

--- a/examples/OpenThermSlave_Demo/OpenThermSlave_Demo.ino
+++ b/examples/OpenThermSlave_Demo/OpenThermSlave_Demo.ino
@@ -12,7 +12,7 @@ const int inPin = 2;  //for Arduino, 12 for ESP8266 (D6), 19 for ESP32
 const int outPin = 3; //for Arduino, 13 for ESP8266 (D7), 23 for ESP32
 OpenTherm ot(inPin, outPin, true);
 
-void ICACHE_RAM_ATTR handleInterrupt() {
+void IRAM_ATTR handleInterrupt() {
     ot.handleInterrupt();
 }
 

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -36,12 +36,12 @@ void OpenTherm::begin(void(*handleInterruptCallback)(void))
 	begin(handleInterruptCallback, NULL);
 }
 
-bool ICACHE_RAM_ATTR OpenTherm::isReady()
+bool IRAM_ATTR OpenTherm::isReady()
 {
 	return status == OpenThermStatus::READY;
 }
 
-int ICACHE_RAM_ATTR OpenTherm::readState() {
+int IRAM_ATTR OpenTherm::readState() {
 	return digitalRead(inPin);
 }
 
@@ -127,7 +127,7 @@ OpenThermResponseStatus OpenTherm::getLastResponseStatus()
 	return responseStatus;
 }
 
-void ICACHE_RAM_ATTR OpenTherm::handleInterrupt()
+void IRAM_ATTR OpenTherm::handleInterrupt()
 {
 	if (isReady())
 	{

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -188,4 +188,8 @@ private:
 #define ICACHE_RAM_ATTR
 #endif
 
+#ifndef IRAM_ATTR
+#define IRAM_ATTR ICACHE_RAM_ATTR
+#endif
+
 #endif // OpenTherm_h


### PR DESCRIPTION
Arduino framework for esp8266 introduced this change with version 3 (to use the same IRAM_ATTR as in ESP32)