### PR TITLE
Correct reading response

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -71,8 +71,10 @@ bool OpenTherm::sendRequestAync(unsigned long request)
 	noInterrupts();
 	const bool ready = isReady();
 
-	if (!ready)
-	  return false;
+	if (!ready) {
+		interrupts();
+		return false;
+	}
 
 	status = OpenThermStatus::REQUEST_SENDING;
 	response = 0;

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -188,7 +188,7 @@ void OpenTherm::process()
 
 	if (st == OpenThermStatus::READY) return;
 	unsigned long newTs = micros();
-	if (st != OpenThermStatus::NOT_INITIALIZED && st != OpenThermStatus::DELAY && (newTs - ts) > 1000000) {
+	if (st != OpenThermStatus::NOT_INITIALIZED && st != OpenThermStatus::RESPONSE_READY && st != OpenThermStatus::DELAY && (newTs - ts) > 1000000) {
 		status = OpenThermStatus::READY;
 		responseStatus = OpenThermResponseStatus::TIMEOUT;
 		if (processResponseCallback != NULL) {


### PR DESCRIPTION
Hi
I noticed a problem reading the response to a request on esp32: most of the responses were TIMEOUT.
This only happened when switching context using yield() or delay() in a loop that calls process(). I'm guessing that the interrupt is triggered falsely.
I studied the opentherm documentation and noticed that the start bit of the response must be expected no earlier than after 20 ms after the request. Some random signal was perceived as a start bit and all further data was distorted.
![Screenshot_2](https://github.com/ihormelnyk/opentherm_library/assets/34578544/5cc50a5f-a668-4a2c-90bc-744723afe905)

After this fix everything started working fine.