### PR TITLE
Fix start bit

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -85,9 +85,9 @@ bool OpenTherm::sendRequestAync(unsigned long request)
 	//Serial.println("Request: " + String(request, HEX));
 	noInterrupts();
 	const bool ready = isReady();
+	interrupts();
 
 	if (!ready) {
-		interrupts();
 		return false;
 	}
 
@@ -105,7 +105,6 @@ bool OpenTherm::sendRequestAync(unsigned long request)
 
 	status = OpenThermStatus::RESPONSE_WAITING;
 	responseTimestamp = micros();
-	interrupts();
 	return true;
 }
 

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -134,7 +134,7 @@ void IRAM_ATTR OpenTherm::handleInterrupt()
 	if (isReady())
 	{
 		if (isSlave && readState() == HIGH) {
-		   status = OpenThermStatus::RESPONSE_WAITING;
+			status = OpenThermStatus::RESPONSE_WAITING;
 		}
 		else {
 			return;
@@ -283,26 +283,26 @@ void OpenTherm::end() {
 const char *OpenTherm::statusToString(OpenThermResponseStatus status)
 {
 	switch (status) {
-		case OpenThermResponseStatus::NONE:	   return "NONE";
-		case OpenThermResponseStatus::SUCCESS: return "SUCCESS";
-		case OpenThermResponseStatus::INVALID: return "INVALID";
-		case OpenThermResponseStatus::TIMEOUT: return "TIMEOUT";
-		default:	                           return "UNKNOWN";
+		case OpenThermResponseStatus::NONE:         return "NONE";
+		case OpenThermResponseStatus::SUCCESS:      return "SUCCESS";
+		case OpenThermResponseStatus::INVALID:      return "INVALID";
+		case OpenThermResponseStatus::TIMEOUT:      return "TIMEOUT";
+		default:                                    return "UNKNOWN";
 	}
 }
 
 const char *OpenTherm::messageTypeToString(OpenThermMessageType message_type)
 {
 	switch (message_type) {
-		case OpenThermMessageType::READ_DATA:	    return "READ_DATA";
-		case OpenThermMessageType::WRITE_DATA:	    return "WRITE_DATA";
-		case OpenThermMessageType::INVALID_DATA:	return "INVALID_DATA";
-		case OpenThermMessageType::RESERVED:		return "RESERVED";
-		case OpenThermMessageType::READ_ACK:		return "READ_ACK";
-		case OpenThermMessageType::WRITE_ACK:	    return "WRITE_ACK";
-		case OpenThermMessageType::DATA_INVALID:	return "DATA_INVALID";
+		case OpenThermMessageType::READ_DATA:       return "READ_DATA";
+		case OpenThermMessageType::WRITE_DATA:      return "WRITE_DATA";
+		case OpenThermMessageType::INVALID_DATA:    return "INVALID_DATA";
+		case OpenThermMessageType::RESERVED:        return "RESERVED";
+		case OpenThermMessageType::READ_ACK:        return "READ_ACK";
+		case OpenThermMessageType::WRITE_ACK:       return "WRITE_ACK";
+		case OpenThermMessageType::DATA_INVALID:    return "DATA_INVALID";
 		case OpenThermMessageType::UNKNOWN_DATA_ID: return "UNKNOWN_DATA_ID";
-		default:			                        return "UNKNOWN";
+		default:                                    return "UNKNOWN";
 	}
 }
 
@@ -383,31 +383,31 @@ float OpenTherm::getBoilerTemperature() {
 }
 
 float OpenTherm::getReturnTemperature() {
-    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::Tret, 0));
-    return isValidResponse(response) ? getFloat(response) : 0;
+	unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::Tret, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
 }
 
 bool OpenTherm::setDHWSetpoint(float temperature) {
-    unsigned int data = temperatureToData(temperature);
-    unsigned long response = sendRequest(buildRequest(OpenThermMessageType::WRITE_DATA, OpenThermMessageID::TdhwSet, data));
-    return isValidResponse(response);
+	unsigned int data = temperatureToData(temperature);
+	unsigned long response = sendRequest(buildRequest(OpenThermMessageType::WRITE_DATA, OpenThermMessageID::TdhwSet, data));
+	return isValidResponse(response);
 }
-    
+	
 float OpenTherm::getDHWTemperature() {
-    unsigned long response = sendRequest(buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::Tdhw, 0));
-    return isValidResponse(response) ? getFloat(response) : 0;
+	unsigned long response = sendRequest(buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::Tdhw, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
 }
 
 float OpenTherm::getModulation() {
-    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::RelModLevel, 0));
-    return isValidResponse(response) ? getFloat(response) : 0;
+	unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::RelModLevel, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
 }
 
 float OpenTherm::getPressure() {
-    unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::CHPressure, 0));
-    return isValidResponse(response) ? getFloat(response) : 0;
+	unsigned long response = sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::CHPressure, 0));
+	return isValidResponse(response) ? getFloat(response) : 0;
 }
 
 unsigned char OpenTherm::getFault() {
-    return ((sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0)) >> 8) & 0xff);
+	return ((sendRequest(buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0)) >> 8) & 0xff);
 }

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -71,8 +71,10 @@ bool OpenTherm::sendRequestAync(unsigned long request)
 	noInterrupts();
 	const bool ready = isReady();
 
-	if (!ready)
-	  return false;
+	if (!ready) {
+		interrupts();
+		return false;
+	}
 
 	status = OpenThermStatus::REQUEST_SENDING;
 	response = 0;

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -188,7 +188,7 @@ void OpenTherm::process()
 
 	if (st == OpenThermStatus::READY) return;
 	unsigned long newTs = micros();
-	if (st != OpenThermStatus::NOT_INITIALIZED && st != OpenThermStatus::DELAY && (newTs - ts) > 1000000) {
+	if (st != OpenThermStatus::NOT_INITIALIZED && st != OpenThermStatus::RESPONSE_READY && st != OpenThermStatus::DELAY && (newTs - ts) > 1000000) {
 		status = OpenThermStatus::READY;
 		responseStatus = OpenThermResponseStatus::TIMEOUT;
 		if (processResponseCallback != NULL) {

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -173,7 +173,7 @@ private:
 	const bool isSlave;
 	unsigned int maxTransmissionWindowTime = 1150000; // 1000ms +15%
 	unsigned int minWaitTimeForStartBit = 0;
-	unsigned int maxWaitTimeForStartBit = 920000; // 850ms +15%
+	unsigned int maxWaitTimeForStartBit = 920000; // 800ms +15%
 
 	volatile unsigned long response;
 	volatile OpenThermResponseStatus responseStatus;

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -117,6 +117,9 @@ public:
 	volatile OpenThermStatus status;
 	void begin(void(*handleInterruptCallback)(void));
 	void begin(void(*handleInterruptCallback)(void), void(*processResponseCallback)(unsigned long, OpenThermResponseStatus));
+	void setMaxTransmissionWindowTime(unsigned int);
+	void setMinWaitTimeForStartBit(unsigned int);
+	void setMaxWaitTimeForStartBit(unsigned int);
 	bool isReady();
 	unsigned long sendRequest(unsigned long request);
 	bool sendResponse(unsigned long request);
@@ -168,10 +171,14 @@ private:
 	const int inPin;
 	const int outPin;
 	const bool isSlave;
+	unsigned int maxTransmissionWindowTime = 1150000; // 1000ms +15%
+	unsigned int minWaitTimeForStartBit = 0;
+	unsigned int maxWaitTimeForStartBit = 920000; // 850ms +15%
 
 	volatile unsigned long response;
 	volatile OpenThermResponseStatus responseStatus;
 	volatile unsigned long responseTimestamp;
+	volatile unsigned long requestTimestamp;
 	volatile byte responseBitIndex;
 
 	int readState();

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -16,7 +16,7 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <stdint.h>
 #include <Arduino.h>
 
-enum class OpenThermResponseStatus {
+enum class OpenThermResponseStatus : byte {
 	NONE,
 	SUCCESS,
 	INVALID,
@@ -24,7 +24,7 @@ enum class OpenThermResponseStatus {
 };
 
 
-enum class OpenThermMessageType {
+enum class OpenThermMessageType : byte {
 	/*  Master to Slave */
 	READ_DATA       = B000,
 	READ            = READ_DATA, // for backwared compatibility
@@ -41,7 +41,7 @@ enum class OpenThermMessageType {
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
 
-enum class OpenThermMessageID {
+enum class OpenThermMessageID : byte {
 	Status, // flag8 / flag8  Master and Slave Status flags.
 	TSet, // f8.8  Control setpoint  ie CH  water temperature setpoint (°C)
 	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code
@@ -98,7 +98,7 @@ enum class OpenThermMessageID {
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
-enum class OpenThermStatus {
+enum class OpenThermStatus : byte {
 	NOT_INITIALIZED,
 	READY,
 	DELAY,

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -16,7 +16,7 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <stdint.h>
 #include <Arduino.h>
 
-enum class OpenThermResponseStatus : byte {
+enum class OpenThermResponseStatus {
 	NONE,
 	SUCCESS,
 	INVALID,
@@ -24,7 +24,7 @@ enum class OpenThermResponseStatus : byte {
 };
 
 
-enum class OpenThermMessageType : byte {
+enum class OpenThermMessageType {
 	/*  Master to Slave */
 	READ_DATA       = B000,
 	READ            = READ_DATA, // for backwared compatibility
@@ -41,7 +41,7 @@ enum class OpenThermMessageType : byte {
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
 
-enum class OpenThermMessageID : byte {
+enum class OpenThermMessageID {
 	Status, // flag8 / flag8  Master and Slave Status flags.
 	TSet, // f8.8  Control setpoint  ie CH  water temperature setpoint (°C)
 	MConfigMMemberIDcode, // flag8 / u8  Master Configuration Flags /  Master MemberID Code
@@ -98,7 +98,7 @@ enum class OpenThermMessageID : byte {
 	SlaveVersion, // u8 / u8  Slave product version number and type
 };
 
-enum class OpenThermStatus : byte {
+enum class OpenThermStatus {
 	NOT_INITIALIZED,
 	READY,
 	DELAY,
@@ -157,12 +157,12 @@ public:
 	unsigned long setBoilerStatus(bool enableCentralHeating, bool enableHotWater = false, bool enableCooling = false, bool enableOutsideTemperatureCompensation = false, bool enableCentralHeating2 = false);
 	bool setBoilerTemperature(float temperature);
 	float getBoilerTemperature();
-    float getReturnTemperature();
-    bool setDHWSetpoint(float temperature);
-    float getDHWTemperature();
-    float getModulation();
-    float getPressure();
-    unsigned char getFault();
+	float getReturnTemperature();
+	bool setDHWSetpoint(float temperature);
+	float getDHWTemperature();
+	float getModulation();
+	float getPressure();
+	unsigned char getFault();
 
 private:
 	const int inPin;


### PR DESCRIPTION
I noticed a problem reading the response to a request on esp32: most of the responses were TIMEOUT.
This only happened when switching context using yield() or delay() in a loop that calls process(). I'm guessing that the interrupt is triggered falsely.
I studied the opentherm documentation and noticed that the start bit of the response must be expected no earlier than after 20 ms after the request. Some random signal was perceived as a start bit and all further data was distorted.
![Screenshot_2](https://github.com/ihormelnyk/opentherm_library/assets/34578544/5cc50a5f-a668-4a2c-90bc-744723afe905)

I also noticed that if I did not call process() for more than 1 second, then even if the response was received successfully (OpenThermStatus::RESPONSE_READY), the response was TIMEOUT. This is fixed in the "timeout fix" commit.

After this fix everything started working fine.

