### PR TITLE
Fix lambda for handleInterrupt

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -277,7 +277,8 @@ void IRAM_ATTR OpenTherm::handleInterrupt()
 }
 
 #if !defined(__AVR__)
-void IRAM_ATTR OpenTherm::handleInterruptHelper(void* ptr) {
+void IRAM_ATTR OpenTherm::handleInterruptHelper(void* ptr)
+{
     static_cast<OpenTherm*>(ptr)->handleInterrupt();
 }
 #endif

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -31,10 +31,12 @@ void OpenTherm::begin(void (*handleInterruptCallback)(void))
     else
     {
 #if !defined(__AVR__)
-        attachInterrupt(
-            digitalPinToInterrupt(inPin), [this]()
-            { this->handleInterrupt(); },
-            CHANGE);
+        attachInterruptArg(
+            digitalPinToInterrupt(inPin),
+            OpenTherm::handleInterruptHelper,
+            this,
+            CHANGE
+        );
 #endif
     }
     activateBoiler();
@@ -273,6 +275,12 @@ void IRAM_ATTR OpenTherm::handleInterrupt()
         }
     }
 }
+
+#if !defined(__AVR__)
+void IRAM_ATTR OpenTherm::handleInterruptHelper(void* ptr) {
+    static_cast<OpenTherm*>(ptr)->handleInterrupt();
+}
+#endif
 
 void OpenTherm::processResponse()
 {

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -186,6 +186,9 @@ public:
     OpenThermResponseStatus getLastResponseStatus();
     static const char *statusToString(OpenThermResponseStatus status);
     void handleInterrupt();
+#if !defined(__AVR__)
+    static void handleInterruptHelper(void* ptr);
+#endif
     void process();
     void end();
 


### PR DESCRIPTION
Hi @ihormelnyk 
On the master branch I noticed a crash with an exception on the ESP8266 board. It looks like this is because lambda functions cannot be placed in IRAM. I used the new ability to call the begin() method without an argument.

This PR fixes this, I tested it on my board.

Similar problem: https://github.com/espressif/esp-idf/issues/2355