### PR TITLE
Fix deprecated messages for new core esp32

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -265,7 +265,7 @@ void IRAM_ATTR OpenTherm::handleInterrupt()
             {
                 response = (response << 1) | !readState();
                 responseTimestamp = newTs;
-                responseBitIndex++;
+                responseBitIndex = responseBitIndex + 1;
             }
             else
             { // stop bit

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -27,17 +27,17 @@ enum class OpenThermResponseStatus : byte
 enum class OpenThermMessageType : byte
 {
     /*  Master to Slave */
-    READ_DATA = B000,
+    READ_DATA = 0b000,
     READ = READ_DATA, // for backwared compatibility
-    WRITE_DATA = B001,
+    WRITE_DATA = 0b001,
     WRITE = WRITE_DATA, // for backwared compatibility
-    INVALID_DATA = B010,
-    RESERVED = B011,
+    INVALID_DATA = 0b010,
+    RESERVED = 0b011,
     /* Slave to Master */
-    READ_ACK = B100,
-    WRITE_ACK = B101,
-    DATA_INVALID = B110,
-    UNKNOWN_DATA_ID = B111
+    READ_ACK = 0b100,
+    WRITE_ACK = 0b101,
+    DATA_INVALID = 0b110,
+    UNKNOWN_DATA_ID = 0b111
 };
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility


### PR DESCRIPTION
When compiling with core 3.0.1 for esp32 we can see ``deprecated`` messages:
```
In file included from .pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.cpp:6:
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:30:17: warning: 'B000' is deprecated: use 0b000 instead [-Wdeprecated-declarations]
   30 |     READ_DATA = B000,
      |                 ^~~~
In file included from C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:41,   
                 from .pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:17:
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:40:3: note: declared here    
   40 |   B000 DEPRECATED(0b000) = 0,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:32:18: warning: 'B001' is deprecated: use 0b001 instead [-Wdeprecated-declarations]
   32 |     WRITE_DATA = B001,
      |                  ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:48:3: note: declared here    
   48 |   B001 DEPRECATED(0b001) = 1,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:34:20: warning: 'B010' is deprecated: use 0b010 instead [-Wdeprecated-declarations]
   34 |     INVALID_DATA = B010,
      |                    ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:55:3: note: declared here    
   55 |   B010 DEPRECATED(0b010) = 2,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:35:16: warning: 'B011' is deprecated: use 0b011 instead [-Wdeprecated-declarations]
   35 |     RESERVED = B011,
      |                ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:62:3: note: declared here    
   62 |   B011 DEPRECATED(0b011) = 3,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:37:16: warning: 'B100' is deprecated: use 0b100 instead [-Wdeprecated-declarations]
   37 |     READ_ACK = B100,
      |                ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:68:3: note: declared here    
   68 |   B100 DEPRECATED(0b100) = 4,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:38:17: warning: 'B101' is deprecated: use 0b101 instead [-Wdeprecated-declarations]
   38 |     WRITE_ACK = B101,
      |                 ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:74:3: note: declared here    
   74 |   B101 DEPRECATED(0b101) = 5,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:39:20: warning: 'B110' is deprecated: use 0b110 instead [-Wdeprecated-declarations]
   39 |     DATA_INVALID = B110,
      |                    ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:80:3: note: declared here    
   80 |   B110 DEPRECATED(0b110) = 6,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:40:23: warning: 'B111' is deprecated: use 0b111 instead [-Wdeprecated-declarations]
   40 |     UNKNOWN_DATA_ID = B111
      |                       ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:86:3: note: declared here    
   86 |   B111 DEPRECATED(0b111) = 7,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.cpp: In member function 'void OpenTherm::handleInterrupt()':  
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.cpp:268:17: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
  268 |                 responseBitIndex++;
      |                 ^~~~~~~~~~~~~~~~
In file included from lib/CustomOpenTherm/CustomOpenTherm.h:2,
                 from src/OpenThermTask.h:1,
                 from src/main.cpp:24:
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:30:17: warning: 'B000' is deprecated: use 0b000 instead [-Wdeprecated-declarations]
   30 |     READ_DATA = B000,
      |                 ^~~~
In file included from C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:41,   
                 from src/main.cpp:1:
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:40:3: note: declared here    
   40 |   B000 DEPRECATED(0b000) = 0,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:32:18: warning: 'B001' is deprecated: use 0b001 instead [-Wdeprecated-declarations]
   32 |     WRITE_DATA = B001,
      |                  ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:48:3: note: declared here    
   48 |   B001 DEPRECATED(0b001) = 1,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:34:20: warning: 'B010' is deprecated: use 0b010 instead [-Wdeprecated-declarations]
   34 |     INVALID_DATA = B010,
      |                    ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:55:3: note: declared here    
   55 |   B010 DEPRECATED(0b010) = 2,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:35:16: warning: 'B011' is deprecated: use 0b011 instead [-Wdeprecated-declarations]
   35 |     RESERVED = B011,
      |                ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:62:3: note: declared here    
   62 |   B011 DEPRECATED(0b011) = 3,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:37:16: warning: 'B100' is deprecated: use 0b100 instead [-Wdeprecated-declarations]
   37 |     READ_ACK = B100,
      |                ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:68:3: note: declared here    
   68 |   B100 DEPRECATED(0b100) = 4,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:38:17: warning: 'B101' is deprecated: use 0b101 instead [-Wdeprecated-declarations]
   38 |     WRITE_ACK = B101,
      |                 ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:74:3: note: declared here    
   74 |   B101 DEPRECATED(0b101) = 5,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:39:20: warning: 'B110' is deprecated: use 0b110 instead [-Wdeprecated-declarations]
   39 |     DATA_INVALID = B110,
      |                    ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:80:3: note: declared here    
   80 |   B110 DEPRECATED(0b110) = 6,
      |   ^~~~
.pio/libdeps/s3_mini/OpenTherm Library/src/OpenTherm.h:40:23: warning: 'B111' is deprecated: use 0b111 instead [-Wdeprecated-declarations]
   40 |     UNKNOWN_DATA_ID = B111
      |                       ^~~~
C:/Users/User/.platformio/packages/framework-arduinoespressif32/cores/esp32/binary.h:86:3: note: declared here    
   86 |   B111 DEPRECATED(0b111) = 7,
      |   ^~~~
```

For reproduce need to use a new core, in platformio.ini:
```ini
;platform = espressif32@^6.7
platform = https://github.com/platformio/platform-espressif32.git
platform_packages =
  ;platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32/archive/refs/tags/2.0.17.zip
  framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.1
  framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.1/esp32-arduino-libs-3.0.1.zip
```