### PR TITLE
Small improvements

### DIFF
--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -399,6 +399,7 @@ bool OpenTherm::isValidRequest(unsigned long request)
 void OpenTherm::end()
 {
     detachInterrupt(digitalPinToInterrupt(inPin));
+    digitalWrite(outPin, LOW);
 }
 
 OpenTherm::~OpenTherm()

--- a/src/OpenTherm.cpp
+++ b/src/OpenTherm.cpp
@@ -400,6 +400,11 @@ void OpenTherm::end()
 {
     detachInterrupt(digitalPinToInterrupt(inPin));
     digitalWrite(outPin, LOW);
+
+    status = OpenThermStatus::NOT_INITIALIZED;
+    response = 0;
+    responseStatus = OpenThermResponseStatus::NONE;
+    responseTimestamp = 0;
 }
 
 OpenTherm::~OpenTherm()

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -226,7 +226,7 @@ public:
     float getPressure();
     unsigned char getFault();
 
-private:
+protected:
     const int inPin;
     const int outPin;
     const bool isSlave;

--- a/src/OpenTherm.h
+++ b/src/OpenTherm.h
@@ -173,7 +173,7 @@ public:
     void begin(std::function<void(unsigned long, OpenThermResponseStatus)> processResponseFunction);
 #endif
     bool isReady();
-    unsigned long sendRequest(unsigned long request);
+    virtual unsigned long sendRequest(unsigned long request);
     bool sendResponse(unsigned long request);
     bool sendRequestAsync(unsigned long request);
     [[deprecated("Use OpenTherm::sendRequestAsync(unsigned long) instead")]]


### PR DESCRIPTION
Hi @ihormelnyk,

I added something that might be useful when extending:
1. Ability to override ``OpenTherm::sendRequest()``. Since it is used in other methods (``OpenTherm::setBoilerStatus()`` and others), without ``virtual`` its logic cannot be changed
2. With inheritance ``private`` adds problems in development, so I suggest changing it to ``protected``

And I think it would be correct to set the out pin state to LOW when calling ``OpenTherm::end()``.
What do you think about these changes? Thanks.