### PR TITLE
use a global instance pointer as a bridge between interrupt and application context

### DIFF
--- a/examples/OpenThermGatewayMonitor_Demo/OpenThermGatewayMonitor_Demo.ino
+++ b/examples/OpenThermGatewayMonitor_Demo/OpenThermGatewayMonitor_Demo.ino
@@ -17,14 +17,24 @@ const int sOutPin = 5; // for Arduino, 13 for ESP8266 (D7), 23 for ESP32
 OpenTherm mOT(mInPin, mOutPin);
 OpenTherm sOT(sInPin, sOutPin, true);
 
+OpenTherm* g_ptr2_mOTinstance = nullptr; // Global bridge
+OpenTherm* g_ptr2_sOTinstance = nullptr; // Global bridge
+
+
 void IRAM_ATTR mHandleInterrupt()
 {
-    mOT.handleInterrupt();
+  if (nullptr != g_ptr2_mOTinstance)
+  {
+    g_ptr2_mOTinstance->handleInterrupt();
+  }
 }
 
 void IRAM_ATTR sHandleInterrupt()
 {
-    sOT.handleInterrupt();
+  if (nullptr != g_ptr2_sOTinstance)
+  {
+    g_ptr2_sOTinstance->handleInterrupt();
+  }
 }
 
 void processRequest(unsigned long request, OpenThermResponseStatus status)
@@ -41,6 +51,10 @@ void processRequest(unsigned long request, OpenThermResponseStatus status)
 void setup()
 {
     Serial.begin(9600);          // 9600 supported by OpenTherm Monitor App
+	
+	g_ptr2_mOTinstance = &mOT;
+	g_ptr2_sOTinstance = &sOT;
+	
     mOT.begin(mHandleInterrupt); // for ESP ot.begin(); without interrupt handler can be used
     sOT.begin(sHandleInterrupt, processRequest);
 }

--- a/examples/OpenThermMaster_Demo/OpenThermMaster_Demo.ino
+++ b/examples/OpenThermMaster_Demo/OpenThermMaster_Demo.ino
@@ -26,9 +26,14 @@ const int inPin = 2;  // for Arduino, 4 for ESP8266 (D2), 21 for ESP32
 const int outPin = 3; // for Arduino, 5 for ESP8266 (D1), 22 for ESP32
 OpenTherm ot(inPin, outPin);
 
+OpenTherm* g_ptr2_OTinstance = nullptr; // Global bridge
+
 void IRAM_ATTR handleInterrupt()
 {
-    ot.handleInterrupt();
+  if (nullptr != g_ptr2_OTinstance)
+  {
+    g_ptr2_OTinstance->handleInterrupt();
+  }
 }
 
 void setup()
@@ -36,6 +41,7 @@ void setup()
     Serial.begin(9600);
     Serial.println("Start");
 
+	g_ptr2_OTinstance = &ot;
     ot.begin(handleInterrupt); // for ESP ot.begin(); without interrupt handler can be used
 }
 

--- a/examples/OpenThermSlave_Demo/OpenThermSlave_Demo.ino
+++ b/examples/OpenThermSlave_Demo/OpenThermSlave_Demo.ino
@@ -12,9 +12,15 @@ const int inPin = 2;  // for Arduino, 12 for ESP8266 (D6), 19 for ESP32
 const int outPin = 3; // for Arduino, 13 for ESP8266 (D7), 23 for ESP32
 OpenTherm ot(inPin, outPin, true);
 
+OpenTherm* g_ptr2_OTinstance = nullptr; // Global bridge
+
+
 void IRAM_ATTR handleInterrupt()
 {
-    ot.handleInterrupt();
+  if (nullptr != g_ptr2_OTinstance)
+  {
+    g_ptr2_OTinstance->handleInterrupt();
+  }
 }
 
 void processRequest(unsigned long request, OpenThermResponseStatus status)
@@ -77,6 +83,7 @@ void setup()
     Serial.begin(9600);
     Serial.println("Start");
 
+	g_ptr2_OTinstance = &ot;
     ot.begin(handleInterrupt, processRequest); // for ESP ot.begin(); without interrupt handler can be used
 }
 


### PR DESCRIPTION
the usage of the 'ot' object in your examples is wrong.
in your examples during execution of the hardware interrupt the 'ot' object is loaded into the interrupt context.
this is time consuming and can causes problems in a lot of applications when it comes to multi threading.